### PR TITLE
Authentication in Local Environment

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -23,3 +23,25 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+
+#amplify-do-not-edit-begin
+amplify/\#current-cloud-backend
+amplify/.config/local-*
+amplify/logs
+amplify/mock-data
+amplify/mock-api-resources
+amplify/backend/amplify-meta.json
+amplify/backend/.temp
+build/
+dist/
+node_modules/
+aws-exports.js
+awsconfiguration.json
+amplifyconfiguration.json
+amplifyconfiguration.dart
+amplify-build-config.json
+amplify-gradle-config.json
+amplifytools.xcconfig
+.secret-*
+**.sample
+#amplify-do-not-edit-end

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "files.exclude": {
+    "amplify/.config": true,
+    "amplify/**/*-parameters.json": true,
+    "amplify/**/amplify.state": true,
+    "amplify/**/transform.conf.json": true,
+    "amplify/#current-cloud-backend": true,
+    "amplify/backend/amplify-meta.json": true,
+    "amplify/backend/awscloudformation": true
+  }
+}

--- a/frontend/amplify/.config/project-config.json
+++ b/frontend/amplify/.config/project-config.json
@@ -1,0 +1,17 @@
+{
+  "providers": [
+    "awscloudformation"
+  ],
+  "projectName": "caseswiftFrontend",
+  "version": "3.1",
+  "frontend": "javascript",
+  "javascript": {
+    "framework": "react",
+    "config": {
+      "SourceDir": "src",
+      "DistributionDir": "build",
+      "BuildCommand": "npm run-script build",
+      "StartCommand": "npm run-script start"
+    }
+  }
+}

--- a/frontend/amplify/backend/auth/caseswiftfrontendcf7ce39b/cli-inputs.json
+++ b/frontend/amplify/backend/auth/caseswiftfrontendcf7ce39b/cli-inputs.json
@@ -1,0 +1,48 @@
+{
+  "version": "1",
+  "cognitoConfig": {
+    "identityPoolName": "caseswiftfrontendcf7ce39b_identitypool_cf7ce39b",
+    "allowUnauthenticatedIdentities": false,
+    "resourceNameTruncated": "caseswcf7ce39b",
+    "userPoolName": "caseswiftfrontendcf7ce39b_userpool_cf7ce39b",
+    "autoVerifiedAttributes": [
+      "email"
+    ],
+    "mfaConfiguration": "OFF",
+    "mfaTypes": [
+      "SMS Text Message"
+    ],
+    "smsAuthenticationMessage": "Your authentication code is {####}",
+    "smsVerificationMessage": "Your verification code is {####}",
+    "emailVerificationSubject": "Your verification code",
+    "emailVerificationMessage": "Your verification code is {####}",
+    "defaultPasswordPolicy": false,
+    "passwordPolicyMinLength": 8,
+    "passwordPolicyCharacters": [],
+    "requiredAttributes": [
+      "email"
+    ],
+    "aliasAttributes": [],
+    "userpoolClientGenerateSecret": false,
+    "userpoolClientRefreshTokenValidity": 30,
+    "userpoolClientWriteAttributes": [
+      "email"
+    ],
+    "userpoolClientReadAttributes": [
+      "email"
+    ],
+    "userpoolClientLambdaRole": "caseswcf7ce39b_userpoolclient_lambda_role",
+    "userpoolClientSetAttributes": false,
+    "sharedId": "cf7ce39b",
+    "resourceName": "caseswiftfrontendcf7ce39b",
+    "authSelections": "identityPoolAndUserPool",
+    "useDefault": "default",
+    "usernameAttributes": [
+      "email"
+    ],
+    "userPoolGroupList": [],
+    "serviceName": "Cognito",
+    "usernameCaseSensitive": false,
+    "useEnabledMfas": true
+  }
+}

--- a/frontend/amplify/backend/backend-config.json
+++ b/frontend/amplify/backend/backend-config.json
@@ -1,0 +1,30 @@
+{
+  "auth": {
+    "caseswiftfrontendcf7ce39b": {
+      "customAuth": false,
+      "dependsOn": [],
+      "frontendAuthConfig": {
+        "mfaConfiguration": "OFF",
+        "mfaTypes": [
+          "SMS"
+        ],
+        "passwordProtectionSettings": {
+          "passwordPolicyCharacters": [],
+          "passwordPolicyMinLength": 8
+        },
+        "signupAttributes": [
+          "EMAIL"
+        ],
+        "socialProviders": [],
+        "usernameAttributes": [
+          "EMAIL"
+        ],
+        "verificationMechanisms": [
+          "EMAIL"
+        ]
+      },
+      "providerPlugin": "awscloudformation",
+      "service": "Cognito"
+    }
+  }
+}

--- a/frontend/amplify/backend/tags.json
+++ b/frontend/amplify/backend/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "user:Stack",
+    "Value": "{project-env}"
+  },
+  {
+    "Key": "user:Application",
+    "Value": "{project-name}"
+  }
+]

--- a/frontend/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/frontend/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -1,0 +1,13 @@
+export type AmplifyDependentResourcesAttributes = {
+  "auth": {
+    "caseswiftfrontendcf7ce39b": {
+      "AppClientID": "string",
+      "AppClientIDWeb": "string",
+      "IdentityPoolId": "string",
+      "IdentityPoolName": "string",
+      "UserPoolArn": "string",
+      "UserPoolId": "string",
+      "UserPoolName": "string"
+    }
+  }
+}

--- a/frontend/amplify/cli.json
+++ b/frontend/amplify/cli.json
@@ -1,0 +1,63 @@
+{
+  "features": {
+    "graphqltransformer": {
+      "addmissingownerfields": true,
+      "improvepluralization": false,
+      "validatetypenamereservedwords": true,
+      "useexperimentalpipelinedtransformer": true,
+      "enableiterativegsiupdates": true,
+      "secondarykeyasgsi": true,
+      "skipoverridemutationinputtypes": true,
+      "transformerversion": 2,
+      "suppressschemamigrationprompt": true,
+      "securityenhancementnotification": false,
+      "showfieldauthnotification": false,
+      "usesubusernamefordefaultidentityclaim": true,
+      "usefieldnameforprimarykeyconnectionfield": false,
+      "enableautoindexquerynames": true,
+      "respectprimarykeyattributesonconnectionfield": true,
+      "shoulddeepmergedirectiveconfigdefaults": false,
+      "populateownerfieldforstaticgroupauth": true
+    },
+    "frontend-ios": {
+      "enablexcodeintegration": true
+    },
+    "auth": {
+      "enablecaseinsensitivity": true,
+      "useinclusiveterminology": true,
+      "breakcirculardependency": true,
+      "forcealiasattributes": false,
+      "useenabledmfas": true
+    },
+    "codegen": {
+      "useappsyncmodelgenplugin": true,
+      "usedocsgeneratorplugin": true,
+      "usetypesgeneratorplugin": true,
+      "cleangeneratedmodelsdirectory": true,
+      "retaincasestyle": true,
+      "addtimestampfields": true,
+      "handlelistnullabilitytransparently": true,
+      "emitauthprovider": true,
+      "generateindexrules": true,
+      "enabledartnullsafety": true,
+      "generatemodelsforlazyloadandcustomselectionset": false
+    },
+    "appsync": {
+      "generategraphqlpermissions": true
+    },
+    "latestregionsupport": {
+      "pinpoint": 1,
+      "translate": 1,
+      "transcribe": 1,
+      "rekognition": 1,
+      "textract": 1,
+      "comprehend": 1
+    },
+    "project": {
+      "overrides": true
+    }
+  },
+  "debug": {
+    "shareProjectConfig": true
+  }
+}

--- a/frontend/amplify/team-provider-info.json
+++ b/frontend/amplify/team-provider-info.json
@@ -1,0 +1,20 @@
+{
+  "dev": {
+    "awscloudformation": {
+      "AuthRoleName": "amplify-caseswiftfrontend-dev-220656-authRole",
+      "UnauthRoleArn": "arn:aws:iam::719017127741:role/amplify-caseswiftfrontend-dev-220656-unauthRole",
+      "AuthRoleArn": "arn:aws:iam::719017127741:role/amplify-caseswiftfrontend-dev-220656-authRole",
+      "Region": "us-east-1",
+      "DeploymentBucketName": "amplify-caseswiftfrontend-dev-220656-deployment",
+      "UnauthRoleName": "amplify-caseswiftfrontend-dev-220656-unauthRole",
+      "StackName": "amplify-caseswiftfrontend-dev-220656",
+      "StackId": "arn:aws:cloudformation:us-east-1:719017127741:stack/amplify-caseswiftfrontend-dev-220656/5f2b3290-5c11-11ee-9454-0efb8fb6ad6d",
+      "AmplifyAppId": "d34cvcllk8gxol"
+    },
+    "categories": {
+      "auth": {
+        "caseswiftfrontendcf7ce39b": {}
+      }
+    }
+  }
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -11,34 +11,44 @@ const root = createRoot(container);
 
 Amplify.Logger.LOG_LEVEL = 'DEBUG';
 
-Amplify.configure({
-  aws_appsync_graphqlEndpoint: process.env.REACT_APP_GRAPHQL_URL,
-  aws_appsync_region: process.env.REACT_APP_REGION,
-  aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
-  Auth: {
-    region: process.env.REACT_APP_REGION,
-    userPoolId: process.env.REACT_APP_COGNTIO_USERPOOL_ID,
-    userPoolWebClientId: process.env.REACT_APP_COGNITO_CLIENT_ID,
-    mandatorySignIn: true,
-    oauth: {
-      domain: process.env.REACT_APP_COGNITO_DOMAIN,
-      scope: ['email', 'openid', `${process.env.REACT_APP_BACKEND_URL}/plaid.rw}`],
-      responseType: 'code'
-    }
-  },
-  API: {
-    endpoints: [
-      {
-        name: "plaidapi",
-        endpoint: process.env.REACT_APP_BACKEND_URL,
+// Try to dynamically import aws-exports
+import('./aws-exports')
+  .then(awsconfig => {
+    // If aws-exports.js is available
+    Amplify.configure(awsconfig.default);
+  })
+  .catch(err => {
+    // If aws-exports.js is NOT available, use the old settings
+    Amplify.configure({
+      aws_appsync_graphqlEndpoint: process.env.REACT_APP_GRAPHQL_URL,
+      aws_appsync_region: process.env.REACT_APP_REGION,
+      aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      Auth: {
         region: process.env.REACT_APP_REGION,
-        clientId: process.env.REACT_APP_COGNITO_CLIENT_ID,
-        custom_header: async () => {
-          return { Authorization: `Bearer ${(await Auth.currentSession()).getAccessToken().getJwtToken()}` }
+        userPoolId: process.env.REACT_APP_COGNTIO_USERPOOL_ID,
+        userPoolWebClientId: process.env.REACT_APP_COGNITO_CLIENT_ID,
+        mandatorySignIn: true,
+        oauth: {
+          domain: process.env.REACT_APP_COGNITO_DOMAIN,
+          scope: ['email', 'openid', `${process.env.REACT_APP_BACKEND_URL}/plaid.rw}`],
+          responseType: 'code'
         }
+      },
+      API: {
+        endpoints: [
+          {
+            name: "plaidapi",
+            endpoint: process.env.REACT_APP_BACKEND_URL,
+            region: process.env.REACT_APP_REGION,
+            clientId: process.env.REACT_APP_COGNITO_CLIENT_ID,
+            custom_header: async () => {
+              return { Authorization: `Bearer ${(await Auth.currentSession()).getAccessToken().getJwtToken()}` }
+            }
+          }
+        ]
       }
-    ]
-  }
-});
-
-root.render(<App />);
+    });
+  })
+  .finally(() => {
+    root.render(<App />);
+  });


### PR DESCRIPTION
Set Up Authentication for Local Frontend Development.

Note to Devs: 
If you want to use auth in the frontend, you'll first have to do the following:
install amplify CLI and initialize it to the AWS Amplify app
then run the following:

```
cd frontend
amplify pull
```

follow the prompts, it should create some local files, then you should be good to go.

This does not point at the current database, this points at its own database for dev purposes.